### PR TITLE
Add RHEL deployment scripts and documentation

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,57 @@
+# Deployment Guide
+
+This document outlines the steps required to deploy PepeTube on a RHEL-based system.
+
+## Prerequisites
+
+* RHEL or compatible distribution
+* Sudo privileges
+
+## Setup
+
+1. Run the setup script to install system dependencies:
+
+   ```bash
+   ./deploy/rhel/setup.sh
+   ```
+
+2. Create a Python virtual environment and install application requirements.
+
+   ```bash
+   python3 -m venv /opt/pepetube/venv
+   /opt/pepetube/venv/bin/pip install -r requirements.txt
+   ```
+
+## Gunicorn Service
+
+1. Copy the provided systemd service file:
+
+   ```bash
+   sudo cp deploy/rhel/gunicorn.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now gunicorn
+   ```
+
+## Nginx Configuration
+
+1. Copy the Nginx configuration:
+
+   ```bash
+   sudo cp deploy/rhel/nginx.conf /etc/nginx/conf.d/pepetube.conf
+   sudo nginx -t
+   sudo systemctl restart nginx
+   ```
+
+## Database Initialization
+
+Configure PostgreSQL as needed, create the database and user for PepeTube.
+
+## Application Deployment
+
+1. Place the PepeTube source code in `/opt/pepetube`.
+2. Ensure the `pepetube` user owns the application directory.
+3. Restart the Gunicorn service after deploying new code:
+
+   ```bash
+   sudo systemctl restart gunicorn
+   ```

--- a/deploy/rhel/gunicorn.service
+++ b/deploy/rhel/gunicorn.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Gunicorn service for PepeTube
+After=network.target
+
+[Service]
+User=pepetube
+Group=pepetube
+WorkingDirectory=/opt/pepetube
+Environment="PATH=/opt/pepetube/venv/bin"
+ExecStart=/opt/pepetube/venv/bin/gunicorn --workers 3 --bind unix:/run/pepetube/pepetube.sock wsgi:app
+RuntimeDirectory=pepetube
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/rhel/nginx.conf
+++ b/deploy/rhel/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://unix:/run/pepetube/pepetube.sock;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/deploy/rhel/setup.sh
+++ b/deploy/rhel/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update system packages
+sudo dnf -y update
+
+# Install Python, PostgreSQL and Nginx
+sudo dnf -y install \
+    python3 python3-virtualenv python3-pip \
+    postgresql-server postgresql-contrib \
+    nginx
+
+# Initialize PostgreSQL if not already initialized
+if [ ! -d /var/lib/pgsql/data/base ]; then
+    sudo postgresql-setup --initdb --unit postgresql
+fi
+
+# Enable and start services
+sudo systemctl enable --now postgresql
+sudo systemctl enable --now nginx
+
+# Open firewall for HTTP/HTTPS if firewalld is present
+if systemctl is-active --quiet firewalld; then
+    sudo firewall-cmd --permanent --add-service=http
+    sudo firewall-cmd --permanent --add-service=https
+    sudo firewall-cmd --reload
+fi


### PR DESCRIPTION
## Summary
- Add setup script for RHEL to install Python, PostgreSQL, and Nginx and enable services.
- Provide systemd service unit and Nginx reverse proxy config for Gunicorn deployment.
- Document administrator deployment steps in DEPLOYMENT.md.

## Testing
- `bash -n deploy/rhel/setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b793d0de8832d902dd6d1627629d9